### PR TITLE
Create selectable interface

### DIFF
--- a/apps/calculator-api/src/app/controllers/amortization/amortization.controller.spec.ts
+++ b/apps/calculator-api/src/app/controllers/amortization/amortization.controller.spec.ts
@@ -9,22 +9,22 @@ describe('AmortizationController', () => {
   const mockAmoriztionMonth: Array<AmortizationMonth> = [
     {
         "label": "1 Month",
-        "month": 1
+        "value": 1
     },
     {
         "label": "2 Months",
-        "month": 2
+        "value": 2
     }
   ];
 
   const mockAmoriztionYears: Array<AmortizationYear> = [
     {
       "label": "1 Year",
-      "year": 1
+      "value": 1
     },
     {
         "label": "2 Years",
-        "year": 2
+        "value": 2
     }
   ];
   beforeEach(async () => {

--- a/apps/calculator-api/src/app/controllers/payment-frequency/payment-frequency.controller.spec.ts
+++ b/apps/calculator-api/src/app/controllers/payment-frequency/payment-frequency.controller.spec.ts
@@ -9,11 +9,11 @@ describe('PaymentFrequencyController', () => {
   const mockPaymentFrequency: Array<PaymentFrequency> = [
     {
       "label": "Weekly",
-      "weeks": 52
+      "value": 52
     },
     {
         "label": "Accelerated Bi-Weekly",
-        "weeks": 26
+        "value": 26
     }
   ];
   beforeEach(async () => {
@@ -44,7 +44,7 @@ describe('PaymentFrequencyController', () => {
       expect( paymentFrequency ).toBeDefined();
       expect( paymentFrequency.length ).toBe( 2 );
       expect( paymentFrequency[0].label ).toBe( 'Weekly' );
-      expect( paymentFrequency[0].weeks ).toBe( 52 );
+      expect( paymentFrequency[0].value ).toBe( 52 );
     } catch (err){
       expect( err ).toBeUndefined();
     }

--- a/apps/calculator-api/src/app/controllers/term/term.controller.spec.ts
+++ b/apps/calculator-api/src/app/controllers/term/term.controller.spec.ts
@@ -8,11 +8,11 @@ describe('TermController', () => {
   const mockTerms: Array<Term> = [
     {
       label: '1 Year',
-      duration: 1,
+      value: 1,
     },
     {
       label: '2 Years',
-      duration: 2,
+      value: 2,
     },
   ];
   beforeEach(async () => {

--- a/docs/Postman/MortgageCalculator.postman_collection.json
+++ b/docs/Postman/MortgageCalculator.postman_collection.json
@@ -18,9 +18,9 @@
 							"",
 							"tests[\"term length\"] = terms.length === 30;",
 							"tests[\"first term label correct\"] = terms[0].label === \"1 Year\";",
-							"tests[\"first term duration correct\"] = terms[0].duration === 1;",
+							"tests[\"first term duration correct\"] = terms[0].value === 1;",
 							"tests[\"second term label correct\"] = terms[1].label === \"2 Years\";",
-							"tests[\"second term duration correct\"] = terms[1].duration === 2;",
+							"tests[\"second term duration correct\"] = terms[1].value === 2;",
 							"",
 							"",
 							"",
@@ -199,7 +199,7 @@
 							"",
 							"tests[\"payment frequency length\"] = paymentFrequency.length === 4;",
 							"tests[\"weekly payment label\"] = paymentFrequency[0].label === 'Weekly';",
-							"tests[\"weekly payment weeks\"] = paymentFrequency[0].weeks === 52;"
+							"tests[\"weekly payment weeks\"] = paymentFrequency[0].value === 52;"
 						],
 						"type": "text/javascript"
 					}

--- a/libs/calculator-service/src/lib/amortization/amortization.service.spec.ts
+++ b/libs/calculator-service/src/lib/amortization/amortization.service.spec.ts
@@ -23,9 +23,9 @@ describe('AmortizationService', () => {
       expect( amortizationYears ).toBeDefined();
       expect( amortizationYears.length ).toBe( 30 );
       expect( amortizationYears[0].label ).toBe( '1 Year');
-      expect( amortizationYears[0].year).toBe( 1 );
+      expect( amortizationYears[0].value).toBe( 1 );
       expect( amortizationYears[1].label ).toBe( '2 Years');
-      expect( amortizationYears[1].year).toBe( 2 );
+      expect( amortizationYears[1].value).toBe( 2 );
     }catch( err ){
       expect( err ).toBeUndefined();
     }
@@ -38,9 +38,9 @@ describe('AmortizationService', () => {
       expect( amortizationMonths ).toBeDefined();
       expect( amortizationMonths.length ).toBe( 12 );
       expect( amortizationMonths[0].label ).toBe( '1 Month');
-      expect( amortizationMonths[0].month).toBe( 1 );
+      expect( amortizationMonths[0].value).toBe( 1 );
       expect( amortizationMonths[1].label ).toBe( '2 Months');
-      expect( amortizationMonths[1].month).toBe( 2 );
+      expect( amortizationMonths[1].value).toBe( 2 );
     }catch( err ){
       expect( err ).toBeUndefined();
     }

--- a/libs/calculator-service/src/lib/amortization/amortization.service.ts
+++ b/libs/calculator-service/src/lib/amortization/amortization.service.ts
@@ -22,12 +22,12 @@ export class AmortizationService {
         if( i === 0){
             aYears = {
                 label: `${year} Year`,
-                year,
+                value: year,
             }
         } else {
             aYears = {
                 label: `${year} Years`,
-                year,
+                value: year,
             }
         }
 
@@ -51,12 +51,12 @@ export class AmortizationService {
             if( i === 0){
                 aMonth = {
                     label: `${month} Month`,
-                    month,
+                    value: month,
                 }
             } else {
                 aMonth = {
                     label: `${month} Months`,
-                    month,
+                    value: month,
                 }
             }
     

--- a/libs/calculator-service/src/lib/payment-frequency/payment-frequency.service.ts
+++ b/libs/calculator-service/src/lib/payment-frequency/payment-frequency.service.ts
@@ -16,22 +16,22 @@ export class PaymentFrequencyService {
 
     paymentFrequency.push( {
         label: `Weekly`,
-        weeks: 52
+        value: 52
     });
 
     paymentFrequency.push( {
         label: `Accelerated Bi-Weekly`,
-        weeks: 26
+        value: 26
     });
 
     paymentFrequency.push( {
         label: `Semi-Monthly`,
-        weeks: 24
+        value: 24
     });
 
     paymentFrequency.push( {
         label: `Monthly`,
-        weeks: 12
+        value: 12
     });
 
     return Promise.resolve(paymentFrequency);

--- a/libs/calculator-service/src/lib/term/term.service.spec.ts
+++ b/libs/calculator-service/src/lib/term/term.service.spec.ts
@@ -34,7 +34,7 @@ describe('TermService', () => {
 
       expect(terms).toBeDefined();
       expect(terms[0].label).toBe('1 Year');
-      expect(terms[0].duration).toBe(1);
+      expect(terms[0].value).toBe(1);
     } catch (err) {
       expect(err).toBeUndefined();
     }
@@ -46,7 +46,7 @@ describe('TermService', () => {
 
       expect(terms).toBeDefined();
       expect(terms[1].label).toBe('2 Years');
-      expect(terms[1].duration).toBe(2);
+      expect(terms[1].value).toBe(2);
     } catch (err) {
       expect(err).toBeUndefined();
     }

--- a/libs/calculator-service/src/lib/term/term.service.ts
+++ b/libs/calculator-service/src/lib/term/term.service.ts
@@ -24,7 +24,7 @@ export class TermService {
       }
       terms[i] = {
         label,
-        duration,
+        value:duration,
       };
     }
     this.logger.log(`Completed Getting terms`);

--- a/libs/models/src/lib/amortization.spec.ts
+++ b/libs/models/src/lib/amortization.spec.ts
@@ -4,11 +4,11 @@ describe('AmortizationYear', () => {
   it('should validate interface AmortizationYear', () => {
     const amortizationYear: AmortizationYear = {
       label: `2 Years`,
-      year: 2,
+      value: 2,
     };
     expect(amortizationYear).toBeDefined();
     expect(amortizationYear.label).toBe('2 Years');
-    expect(amortizationYear.year).toBe(2);
+    expect(amortizationYear.value).toBe(2);
   });
 });
 
@@ -16,11 +16,11 @@ describe('AmortizationMonth', () => {
   it('should validate interface AmortizationMonth', () => {
     const amortizationMonth: AmortizationMonth = {
       label: `2 Month`,
-      month: 2,
+      value: 2,
     };
     expect(amortizationMonth).toBeDefined();
     expect(amortizationMonth.label).toBe('2 Month');
-    expect(amortizationMonth.month).toBe(2);
+    expect(amortizationMonth.value).toBe(2);
   });
 });
 
@@ -30,13 +30,13 @@ describe('AmortizationPeriod', () => {
       months: [
         {
           label: `1 Month`,
-          month: 1,
+          value: 1,
         }
       ],
       years: [
         {
           label: `2 Years`,
-          year: 2,
+          value: 2,
         }
       ]
     };

--- a/libs/models/src/lib/amortization.ts
+++ b/libs/models/src/lib/amortization.ts
@@ -1,4 +1,4 @@
-export interface AmortizationYear {
+export interface AmortizationYear  {
   label: string;
   year: number;
 };

--- a/libs/models/src/lib/amortization.ts
+++ b/libs/models/src/lib/amortization.ts
@@ -1,12 +1,8 @@
-export interface AmortizationYear  {
-  label: string;
-  year: number;
-};
+import { Selectable } from "./selectable";
 
-export interface AmortizationMonth {
-  label: string;
-  month: number;
-}
+export interface AmortizationYear extends Selectable  {};
+
+export interface AmortizationMonth extends Selectable {}
 
 export interface AmortizationPeriod {
   years: AmortizationYear[];

--- a/libs/models/src/lib/amortization.ts
+++ b/libs/models/src/lib/amortization.ts
@@ -1,8 +1,8 @@
 import { Selectable } from "./selectable";
 
-export interface AmortizationYear extends Selectable  {};
+export type AmortizationYear = Selectable;
 
-export interface AmortizationMonth extends Selectable {}
+export type AmortizationMonth = Selectable
 
 export interface AmortizationPeriod {
   years: AmortizationYear[];

--- a/libs/models/src/lib/payment-frequency.spec.ts
+++ b/libs/models/src/lib/payment-frequency.spec.ts
@@ -4,10 +4,10 @@ describe('PaymentFrequency', () => {
   it('should validate interface PaymentFrequency', () => {
     const paymentFrequency: PaymentFrequency = {
       label: 'Monthly',
-      weeks: 12,
+      value: 12,
     };
     expect(paymentFrequency).toBeDefined();
     expect(paymentFrequency.label).toBe('Monthly');
-    expect(paymentFrequency.weeks).toBe(12);
+    expect(paymentFrequency.value).toBe(12);
   });
 });

--- a/libs/models/src/lib/payment-frequency.ts
+++ b/libs/models/src/lib/payment-frequency.ts
@@ -1,5 +1,3 @@
-export interface PaymentFrequency {
-  label: string;
-  weeks: number;
-};
+import { Selectable } from './selectable';
+export type PaymentFrequency = Selectable;
 

--- a/libs/models/src/lib/selectable.spec.ts
+++ b/libs/models/src/lib/selectable.spec.ts
@@ -1,0 +1,13 @@
+import { Selectable } from './selectable';
+
+describe('Selectable', () => {
+  it('should validate interface Selectable', () => {
+    const selectable: Selectable = {
+      label: 'Monthly',
+      value: 12,
+    };
+    expect(selectable).toBeDefined();
+    expect(selectable.label).toBe('Monthly');
+    expect(selectable.value).toBe(12);
+  });
+});

--- a/libs/models/src/lib/selectable.ts
+++ b/libs/models/src/lib/selectable.ts
@@ -1,0 +1,4 @@
+export interface Selectable {
+    label: string;
+    value: number;
+  };

--- a/libs/models/src/lib/term.spec.ts
+++ b/libs/models/src/lib/term.spec.ts
@@ -4,11 +4,11 @@ describe('Term', () => {
   it('should validate interface Term exists', () => {
     const term: Term = {
       label: '12 Years',
-      duration: 12,
+      value: 12,
     };
 
     expect(term).toBeDefined();
-    expect(term.duration).toBe(12);
+    expect(term.value).toBe(12);
     expect(term.label).toBe('12 Years');
   });
 });

--- a/libs/models/src/lib/term.ts
+++ b/libs/models/src/lib/term.ts
@@ -1,4 +1,3 @@
-export interface Term {
-  label: string;
-  duration: number;
-}
+import { Selectable } from './selectable';
+
+export interface Term extends Selectable{};

--- a/libs/models/src/lib/term.ts
+++ b/libs/models/src/lib/term.ts
@@ -1,3 +1,3 @@
 import { Selectable } from './selectable';
 
-export interface Term extends Selectable{};
+export type Term = Selectable;


### PR DESCRIPTION
The following PR is in support of making a generic type for Term, Amortization and Payment Frequency.  All these types will be displayed within an Option Select and to make more of a generic component I decided to make a Selectable Interface that would allow the UI to create a single option component that has one generic interface.  this PR includes the following:

1. Create a generic selectable interface
2. Update the Term (including model, service and controller as well as test cases)
3. Update the Payment Frequency (including model, service and controller as well as test cases)
4. Update the Amortization (including model, service and controller as well as test cases)
5. Fix the postman tests to reflect the changes