### PR TITLE
Add healthcheck api

### DIFF
--- a/apps/calculator-api/src/app/app.module.ts
+++ b/apps/calculator-api/src/app/app.module.ts
@@ -5,10 +5,17 @@ import { CalculatorServiceModule } from '@mortgage-calculator/calculator-service
 import { InterestRateController } from './controllers/interest-rate/interest-rate.controller';
 import { AmortizationController } from './controllers/amortization/amortization.controller';
 import { PaymentFrequencyController } from './controllers/payment-frequency/payment-frequency.controller';
+import { HealthCheckController } from './controllers/health-check/health-check.controller';
 
 @Module({
   imports: [CalculatorServiceModule],
-  controllers: [TermController, InterestRateController, AmortizationController, PaymentFrequencyController],
+  controllers: [
+    TermController,
+    InterestRateController,
+    AmortizationController,
+    PaymentFrequencyController,
+    HealthCheckController,
+  ],
   providers: [],
 })
 export class AppModule {}

--- a/apps/calculator-api/src/app/controllers/health-check/health-check.controller.spec.ts
+++ b/apps/calculator-api/src/app/controllers/health-check/health-check.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthCheckController } from './health-check.controller';
+
+describe('HealthCheckController', () => {
+  let controller: HealthCheckController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthCheckController],
+    }).compile();
+
+    controller = module.get<HealthCheckController>(HealthCheckController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/calculator-api/src/app/controllers/health-check/health-check.controller.spec.ts
+++ b/apps/calculator-api/src/app/controllers/health-check/health-check.controller.spec.ts
@@ -15,4 +15,14 @@ describe('HealthCheckController', () => {
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
+
+  it('should get health check', async () => {
+    try{
+      const healthCheck = await controller.getHealthStatus();
+      expect( healthCheck ).toBeDefined();
+      expect( healthCheck.statusId ).toBe( '4' );
+    } catch (err){
+      expect( err ).toBeUndefined();
+    }
+  });
 });

--- a/apps/calculator-api/src/app/controllers/health-check/health-check.controller.ts
+++ b/apps/calculator-api/src/app/controllers/health-check/health-check.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Logger } from '@nestjs/common';
+
+const STATUS_ID = process.env.HEALTH_ID|| '4';
+
+interface HealthStatus {
+
+    status: boolean;
+    statusId: string;
+}
+
+@Controller('health-check')
+export class HealthCheckController {
+    private readonly logger = new Logger(HealthCheckController.name);
+
+    @Get()
+    async getHealthStatus(): Promise<HealthStatus> {
+      this.logger.log(`Getting List of Terms`);
+      try {
+
+        const status: HealthStatus = {
+            status:true,
+            statusId: STATUS_ID 
+        };
+        const statusResponse: Promise<HealthStatus> = Promise.resolve( status );
+  
+        return statusResponse;
+      } catch (err) {
+        console.log(`Error.  Change don't swallow error`);
+        throw err;
+      }
+    }
+}

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -18,3 +18,10 @@ spec:
           ports:
             - containerPort: 3333
           imagePullPolicy: Never # Image should not be pulled
+          livenessProbe:
+            httpGet:
+              path: /api/health-check
+              port: 3333
+            initialDelaySeconds: 3
+            periodSeconds: 3
+            failureThreshold: 2

--- a/docs/Postman/MortgageCalculator.postman_collection.json
+++ b/docs/Postman/MortgageCalculator.postman_collection.json
@@ -221,6 +221,43 @@
 				"description": "The following request will make a call to get Payment Frequency"
 			},
 			"response": []
+		},
+		{
+			"name": "Get Health Check",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"var status = JSON.parse(responseBody);",
+							"",
+							"tests[\"status\"] = status.status === true;",
+							"",
+							"",
+							"",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{hostname}}/api/health-check",
+					"host": [
+						"{{hostname}}"
+					],
+					"path": [
+						"api",
+						"health-check"
+					]
+				},
+				"description": "The following request will make a call to get health check"
+			},
+			"response": []
 		}
 	]
 }


### PR DESCRIPTION
The following PR adds basic health check support to the calculator api and kubernetes deployment.  Here is a summary of the PR:
1. Create a new endpoint on the controller that provides basic health check status
2. Update the K8s deployment to look for the new liveness probe api.