### PR TITLE
Add k8s config map

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,15 @@ A list of common NX Commands for development:
 A list of common git commands used during development:
 [GIT Helper](docs/GIT-HELPER-COMMANDS.md)
 
-# TO Do list
+# To Do list
 
 There is a small TODO file that is being used:
 [TODO](docs/TODO.md)
+
+# Kubernetes configuration
+
+There is a small file with some helper configuration
+[Kubernetes Helper](docs/MINI-KUBE-SETUP.md)
 
 There is also a project tracked in github
 

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -25,3 +25,9 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 3
             failureThreshold: 2
+          env:
+            - name: HEALTH_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: calculator-envs
+                  key: healthId

--- a/deployment/envs.yaml
+++ b/deployment/envs.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: calculator-envs
+data:
+  healthId: "10"

--- a/docs/MINI-KUBE-SETUP.md
+++ b/docs/MINI-KUBE-SETUP.md
@@ -19,6 +19,24 @@ minikube dashboard
 
 # Minikube Deployment
 
+## Setup Environment (ConfigMap) 
+The following command will deploy config map to the environment
+```
+kubectl apply -f deployment/envs.yaml
+```
+
+## Get the list of config maps
+
+```
+kubectl get configmap
+```
+
+## Get the data from the config map
+
+```
+kubectl get configmaps calculator-envs -o yaml
+```
+
 ## Deploy the Deployment
 ```
 kubectl apply -f deployment/deployment.yaml


### PR DESCRIPTION
The following PR is used to setup a config map to be used to pass environment variables to the deployment and pods.  It also updates the documentation to help explain the process