### PR TITLE
Refactor input form props

### DIFF
--- a/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.delegate.spec.ts
+++ b/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.delegate.spec.ts
@@ -1,12 +1,10 @@
-import {IMortgageInitialParameters, loadMortgageInitialParameters} from './calculator-input-form.delegate';
+import { loadMortgageInitialParameters } from './calculator-input-form.delegate';
 
 describe( 'Calculator Input Form Delegate ', () =>{
 
     it('Should test loadMortgageInitialParameters', async()=>{
         try{
-            const rst: IMortgageInitialParameters = await loadMortgageInitialParameters();
-            expect( rst ).toBeDefined();
-
+            expect( loadMortgageInitialParameters ).toBeDefined();
         }catch( err ){
             expect( err )
         }

--- a/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.delegate.ts
+++ b/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.delegate.ts
@@ -1,6 +1,5 @@
 import { AmortizationPeriod, InterestRate, PaymentFrequency, RateType, Term } from "@mortgage-calculator/models";
 import { fetchAmoritizationPeriod, fetchInterestRate, fetchPaymentFrequency, fetchRateTypes, fetchTerms } from "../../store/fixeddata/fixedData.effect";
-// import {getAmortizationPeriod, getInterestRate, getPaymentFrequency, getTerms} from './calculator-input-form.mock';
 
 export interface IMortgageInitialParameters {
     interestRate?: InterestRate,
@@ -14,17 +13,6 @@ export interface IMortgageInitialParameters {
  * @param rateType 
  */
 export const loadMortgageInitialParameters = async ( rateType: RateType =RateType.FIXED ): Promise<void> =>{
-    /*const terms: Term[] = await getTerms();
-    const interestRate:InterestRate = await getInterestRate( rateType);
-    const amortizationPeriod: AmortizationPeriod = await getAmortizationPeriod();
-    const paymentFrequencies: PaymentFrequency[] = await getPaymentFrequency();
-
-    return {
-        terms,
-        interestRate,
-        amortizationPeriod,
-        paymentFrequencies,
-    };*/
 
     await fetchTerms();
     await fetchRateTypes();

--- a/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.delegate.ts
+++ b/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.delegate.ts
@@ -1,5 +1,6 @@
 import { AmortizationPeriod, InterestRate, PaymentFrequency, RateType, Term } from "@mortgage-calculator/models";
-import {getAmortizationPeriod, getInterestRate, getPaymentFrequency, getTerms} from './calculator-input-form.mock';
+import { fetchAmoritizationPeriod, fetchInterestRate, fetchPaymentFrequency, fetchRateTypes, fetchTerms } from "../../store/fixeddata/fixedData.effect";
+// import {getAmortizationPeriod, getInterestRate, getPaymentFrequency, getTerms} from './calculator-input-form.mock';
 
 export interface IMortgageInitialParameters {
     interestRate?: InterestRate,
@@ -12,8 +13,8 @@ export interface IMortgageInitialParameters {
  * The following function will get initial data
  * @param rateType 
  */
-export const loadMortgageInitialParameters = async ( rateType: RateType =RateType.FIXED ): Promise<IMortgageInitialParameters> =>{
-    const terms: Term[] = await getTerms();
+export const loadMortgageInitialParameters = async ( rateType: RateType =RateType.FIXED ): Promise<void> =>{
+    /*const terms: Term[] = await getTerms();
     const interestRate:InterestRate = await getInterestRate( rateType);
     const amortizationPeriod: AmortizationPeriod = await getAmortizationPeriod();
     const paymentFrequencies: PaymentFrequency[] = await getPaymentFrequency();
@@ -23,5 +24,11 @@ export const loadMortgageInitialParameters = async ( rateType: RateType =RateTyp
         interestRate,
         amortizationPeriod,
         paymentFrequencies,
-    };
+    };*/
+
+    await fetchTerms();
+    await fetchRateTypes();
+    await fetchAmoritizationPeriod();
+    await fetchPaymentFrequency();
+    await fetchInterestRate( 'FIXED' );
 };

--- a/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.mock.ts
+++ b/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.mock.ts
@@ -1,8 +1,6 @@
-
 /**
  * The following is a temporary mock file for generating data
  */
-
 import { AmortizationPeriod, InterestRate, PaymentFrequency, RateType, Term } from "@mortgage-calculator/models";
 
 /**

--- a/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.spec.tsx
+++ b/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.spec.tsx
@@ -4,8 +4,6 @@ import CalculatorInputForm, { CalculatorInputFormProps } from './calculator-inpu
 
 jest.mock('@mortgage-calculator/shared-ui-react', () => ({ CalculatorSelect: () => 'mocked calculator select', NumericCalculatorInput: () => 'mocked numeric calculator input' }));
 
-
-
 describe('CalculatorInputForm', () => {
   it('should render successfully', async () => {
     try{
@@ -18,7 +16,63 @@ describe('CalculatorInputForm', () => {
         interestRateType: RateType.FIXED,
         paymentFrequency: 52,
         term: 5,
-        handleChange: jest.fn()
+        handleChange: jest.fn(),
+        initialMortgageDetails : {
+          interestRate: {
+            type: RateType.FIXED,
+            rate: 1.02
+          },
+          terms: [
+            {
+              "label": "1 Year",
+              "value": 1
+            },
+            {
+                "label": "2 Years",
+                "value": 2
+            }
+          ],
+          paymentFrequencies: [
+            {
+              "label": "Weekly",
+              "value": 52
+            },
+            {
+                "label": "Accelerated Bi-Weekly",
+                "value": 26
+            },
+            {
+                "label": "Semi-Monthly",
+                "value": 24
+            },
+            {
+                "label": "Monthly",
+                "value": 12
+            }
+          ],
+          amortizationPeriod: {
+            months: [
+              {
+                  "label": "1 Month",
+                  "value": 1
+              },
+              {
+                  "label": "2 Months",
+                  "value": 2
+              }
+            ],
+            years: [
+              {
+                "label": "1 Year",
+                "value": 1
+              },
+              {
+                  "label": "2 Years",
+                  "value": 2
+              }
+            ]
+          }
+        }
       };
 
       await act( async ()=> {

--- a/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.stories.tsx
+++ b/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.stories.tsx
@@ -19,6 +19,62 @@ const inputFormProps: CalculatorInputFormProps = {
   term: 5,
   handleChange: ( eventName: string, value:number|string ) =>{
     action('Handle Change fired');
+  },
+  initialMortgageDetails : {
+    interestRate: {
+      type: RateType.FIXED,
+      rate: 1.02
+    },
+    terms: [
+      {
+        "label": "1 Year",
+        "value": 1
+      },
+      {
+          "label": "2 Years",
+          "value": 2
+      }
+    ],
+    paymentFrequencies: [
+      {
+        "label": "Weekly",
+        "value": 52
+      },
+      {
+          "label": "Accelerated Bi-Weekly",
+          "value": 26
+      },
+      {
+          "label": "Semi-Monthly",
+          "value": 24
+      },
+      {
+          "label": "Monthly",
+          "value": 12
+      }
+    ],
+    amortizationPeriod: {
+      months: [
+        {
+            "label": "1 Month",
+            "value": 1
+        },
+        {
+            "label": "2 Months",
+            "value": 2
+        }
+      ],
+      years: [
+        {
+          "label": "1 Year",
+          "value": 1
+        },
+        {
+            "label": "2 Years",
+            "value": 2
+        }
+      ]
+    }
   }
 };
 

--- a/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.tsx
+++ b/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.tsx
@@ -37,26 +37,27 @@ export interface CalculatorInputFormProps {
   paymentFrequency: number;
   term: number;
   handleChange: ( eventName: string, value:number|string ) =>void;
+  initialMortgageDetails:IMortgageInitialParameters;
 }
 
 export const CalculatorInputForm = (props: CalculatorInputFormProps) => {
 
- const [ mortgageParameters, setMortgageParameters ] = useState<IMortgageInitialParameters> ({
+ /*const [ mortgageParameters, setMortgageParameters ] = useState<IMortgageInitialParameters> ({
   interestRate: undefined,
   amortizationPeriod: undefined,
   paymentFrequencies: [],
   terms: []
- });
+ });*/
 
   //Need a function to load the data and set the variables to local values
   // Load the data only once
-  useEffect( () => {
+  /*useEffect( () => {
     const loadInitialComponentData = async() =>{
-      const initialMortgageDetails:IMortgageInitialParameters = await loadMortgageInitialParameters();
-      setMortgageParameters({...initialMortgageDetails})
+      // const initialMortgageDetails:IMortgageInitialParameters = await loadMortgageInitialParameters();
+      //setMortgageParameters({...initialMortgageDetails})
     }
     loadInitialComponentData();
-  }, []);
+  }, []);*/
 
   const classes = useStyles();
   return (
@@ -93,10 +94,10 @@ export const CalculatorInputForm = (props: CalculatorInputFormProps) => {
         </Grid>
         <Grid item container xs={7} className={classes.fieldBottom}>
           <Grid item xs={6}>
-            <CalculatorSelect { ...getAmortizationYearsProps( props.handleChange, mortgageParameters?.amortizationPeriod?.years ) }/>
+            <CalculatorSelect { ...getAmortizationYearsProps( props.handleChange, props.initialMortgageDetails?.amortizationPeriod?.years ) }/>
           </Grid>
           <Grid item xs={6}>
-          <CalculatorSelect { ...getAmortizationMonthsProps( props.handleChange, mortgageParameters?.amortizationPeriod?.months) }/>
+          <CalculatorSelect { ...getAmortizationMonthsProps( props.handleChange, props.initialMortgageDetails?.amortizationPeriod?.months) }/>
           </Grid>
         </Grid>
 
@@ -104,14 +105,14 @@ export const CalculatorInputForm = (props: CalculatorInputFormProps) => {
           <Typography variant="body1">Payment Frequency:</Typography>
         </Grid>
         <Grid item xs={7} className={classes.fieldBottom}>
-          <CalculatorSelect { ...getPaymentFrequencyProps( props.handleChange, mortgageParameters?.paymentFrequencies ) }/>
+          <CalculatorSelect { ...getPaymentFrequencyProps( props.handleChange, props.initialMortgageDetails?.paymentFrequencies ) }/>
         </Grid>
 
         <Grid item xs={5}>
           <Typography variant="body1">Term:</Typography>
         </Grid>
         <Grid item xs={7} className={classes.fieldBottom}>
-          <CalculatorSelect { ...getTermProps( props.handleChange, mortgageParameters?.terms ) }/>
+          <CalculatorSelect { ...getTermProps( props.handleChange, props.initialMortgageDetails?.terms ) }/>
         </Grid>
       </Grid>
 

--- a/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.tsx
+++ b/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-form.tsx
@@ -1,5 +1,4 @@
 import './calculator-input-form.module.scss';
-import { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import {
   Grid,
@@ -41,23 +40,6 @@ export interface CalculatorInputFormProps {
 }
 
 export const CalculatorInputForm = (props: CalculatorInputFormProps) => {
-
- /*const [ mortgageParameters, setMortgageParameters ] = useState<IMortgageInitialParameters> ({
-  interestRate: undefined,
-  amortizationPeriod: undefined,
-  paymentFrequencies: [],
-  terms: []
- });*/
-
-  //Need a function to load the data and set the variables to local values
-  // Load the data only once
-  /*useEffect( () => {
-    const loadInitialComponentData = async() =>{
-      // const initialMortgageDetails:IMortgageInitialParameters = await loadMortgageInitialParameters();
-      //setMortgageParameters({...initialMortgageDetails})
-    }
-    loadInitialComponentData();
-  }, []);*/
 
   const classes = useStyles();
   return (

--- a/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-props.builder.spec.ts
+++ b/apps/calculator-ui-react/src/app/components/calculator-input-form/calculator-input-props.builder.spec.ts
@@ -57,8 +57,4 @@ describe( 'Calculator Input Props Builder ', () =>{
         expect( termsProps ).toBeDefined();
         expect( termsProps.optionsList.length).toBe( 0 );
     });
-    
-    
-    
-
 });

--- a/apps/calculator-ui-react/src/app/pages/mortgage-calculator.page.tsx
+++ b/apps/calculator-ui-react/src/app/pages/mortgage-calculator.page.tsx
@@ -4,7 +4,8 @@ import {CalculatorInputForm, CalculatorInputFormProps } from '../components/calc
 import { AmortizationPeriod, InterestRate, MortgageDetails, PaymentFrequency, RateType, Term } from "@mortgage-calculator/models";
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { calculateMortgage } from  '../store/mortgage-calculation/mortgageSlice';
-import { fetchAmoritizationPeriod, fetchInterestRate, fetchPaymentFrequency, fetchRateTypes, fetchTerms } from "../store/fixeddata/fixedData.effect";
+// import { fetchAmoritizationPeriod, fetchInterestRate, fetchPaymentFrequency, fetchRateTypes, fetchTerms } from "../store/fixeddata/fixedData.effect";
+import { loadMortgageInitialParameters, IMortgageInitialParameters } from '../components/calculator-input-form/calculator-input-form.delegate';
 
 const useStyles = makeStyles({
   fieldBottom: {
@@ -22,23 +23,30 @@ const MortgageCalculator = () => {
      }) )
   }
   // update initial mortgageDetails state on user entry
-  const terms: Array<Term> = useAppSelector( state => state.terms.data );
+  //const terms: Array<Term> = useAppSelector( state => state.terms.data );
   const termsError: string = useAppSelector ( state => state.terms.errorMessage );
   const rateTypes: Array<string> = useAppSelector( state => state.rateType.data);
   const rateTypesError: string = useAppSelector( state => state.rateType.errorMessage);
-  const amortizationPeriod: AmortizationPeriod = useAppSelector( state => state.amortization.data);
+  //const amortizationPeriod: AmortizationPeriod = useAppSelector( state => state.amortization.data);
   const amortizationError: string  = useAppSelector( state => state.amortization.errorMessage );
-  const paymentFrequency: Array<PaymentFrequency> = useAppSelector( state => state.paymentFrequency.data );
+  //const paymentFrequency: Array<PaymentFrequency> = useAppSelector( state => state.paymentFrequency.data );
   const paymentFrequencyError: string = useAppSelector( state => state.paymentFrequency.errorMessage );
-  const interestRate: InterestRate = useAppSelector( state => state.interestRate.data );
+  //const interestRate: InterestRate = useAppSelector( state => state.interestRate.data );
   const interestRateError: string = useAppSelector( state => state.interestRate.errorMessage );
 
-  const loadInitialData = async () => {
+  /*const loadInitialData = async () => {
     await fetchTerms();
     await fetchRateTypes();
     await fetchAmoritizationPeriod();
     await fetchPaymentFrequency();
     await fetchInterestRate( 'FIXED' );
+  }*/
+
+  const initialMortgageDetails: IMortgageInitialParameters = {
+    terms: useAppSelector( state => state.terms.data ),
+    interestRate: useAppSelector( state => state.interestRate.data ),
+    amortizationPeriod: useAppSelector( state => state.amortization.data),
+    paymentFrequencies: useAppSelector( state => state.paymentFrequency.data )
   }
 
   const [mortgageDetails, setMortgageDetails] = useState<MortgageDetails>({
@@ -49,7 +57,7 @@ const MortgageCalculator = () => {
       amortizationMonth: 2,
       interestRateType: RateType.FIXED,
       paymentFrequency: 52,
-      term: 5
+      term: 5,
     });
 
     const handleChange = (eventName: string, eventValue :number|string) => {
@@ -68,12 +76,15 @@ const MortgageCalculator = () => {
 
   // calculate mortgage on initial render
   useEffect(() => {
-    loadInitialData();
+    // loadInitialData();
+    loadMortgageInitialParameters();
   }, []);
 
   const inputPropoForm: CalculatorInputFormProps = {
-    ...mortgageDetails, 
-    handleChange
+    ...mortgageDetails,
+    handleChange,
+    initialMortgageDetails
+
   }
 
   return (

--- a/apps/calculator-ui-react/src/app/pages/mortgage-calculator.page.tsx
+++ b/apps/calculator-ui-react/src/app/pages/mortgage-calculator.page.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import {CalculatorInputForm, CalculatorInputFormProps } from '../components/calculator-input-form/calculator-input-form'
-import { AmortizationPeriod, InterestRate, MortgageDetails, PaymentFrequency, RateType, Term } from "@mortgage-calculator/models";
+import { MortgageDetails, RateType } from "@mortgage-calculator/models";
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { calculateMortgage } from  '../store/mortgage-calculation/mortgageSlice';
-// import { fetchAmoritizationPeriod, fetchInterestRate, fetchPaymentFrequency, fetchRateTypes, fetchTerms } from "../store/fixeddata/fixedData.effect";
+
 import { loadMortgageInitialParameters, IMortgageInitialParameters } from '../components/calculator-input-form/calculator-input-form.delegate';
 
 const useStyles = makeStyles({
@@ -22,25 +22,13 @@ const MortgageCalculator = () => {
       [eventName]: eventValue
      }) )
   }
-  // update initial mortgageDetails state on user entry
-  //const terms: Array<Term> = useAppSelector( state => state.terms.data );
+
   const termsError: string = useAppSelector ( state => state.terms.errorMessage );
   const rateTypes: Array<string> = useAppSelector( state => state.rateType.data);
   const rateTypesError: string = useAppSelector( state => state.rateType.errorMessage);
-  //const amortizationPeriod: AmortizationPeriod = useAppSelector( state => state.amortization.data);
   const amortizationError: string  = useAppSelector( state => state.amortization.errorMessage );
-  //const paymentFrequency: Array<PaymentFrequency> = useAppSelector( state => state.paymentFrequency.data );
   const paymentFrequencyError: string = useAppSelector( state => state.paymentFrequency.errorMessage );
-  //const interestRate: InterestRate = useAppSelector( state => state.interestRate.data );
   const interestRateError: string = useAppSelector( state => state.interestRate.errorMessage );
-
-  /*const loadInitialData = async () => {
-    await fetchTerms();
-    await fetchRateTypes();
-    await fetchAmoritizationPeriod();
-    await fetchPaymentFrequency();
-    await fetchInterestRate( 'FIXED' );
-  }*/
 
   const initialMortgageDetails: IMortgageInitialParameters = {
     terms: useAppSelector( state => state.terms.data ),
@@ -76,7 +64,6 @@ const MortgageCalculator = () => {
 
   // calculate mortgage on initial render
   useEffect(() => {
-    // loadInitialData();
     loadMortgageInitialParameters();
   }, []);
 
@@ -84,7 +71,6 @@ const MortgageCalculator = () => {
     ...mortgageDetails,
     handleChange,
     initialMortgageDetails
-
   }
 
   return (

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,5 @@
 # React App next steps
-1. Update the input component to pass fixed data
+1. ~~Update the input component to pass fixed data~~
 2. Create a GraphQL API to perform calculation
 3. Create a UI component to display the data and perform calculation
 4. Create a NGINX Container to serve the static


### PR DESCRIPTION
The following PR will refactor the Calculator Input Form to pass the initial mortgage properties from the parent page to the child component.  This has been tagged as an issue in #30 .

This PR includes the following fields:
1. Refactor the delegate to call the effects to update the central store
2. Remove the useState and mock from the Input Calculator Component
3. Trigger the load data from the main page and pass as props to the child component 