### PR TITLE
Integrate mortgage calculation api

### DIFF
--- a/libs/models/src/index.ts
+++ b/libs/models/src/index.ts
@@ -5,3 +5,4 @@ export * from './lib/amortization';
 export * from './lib/payment-frequency';
 export * from './lib/mortgage-details';
 export * from './lib/health-status';
+export * from './lib/mortgage-result';

--- a/libs/models/src/lib/mortgage-result.spec.ts
+++ b/libs/models/src/lib/mortgage-result.spec.ts
@@ -1,0 +1,13 @@
+import { MortgageResult } from './mortgage-result';
+
+describe('MortgageResult', () => {
+  it('should validate interface MortgageResult', () => {
+    const mortgageResult: MortgageResult = {
+        monthlyPayment: 1231123.01,
+        id: "1231233213",
+        creationDate: new Date()
+    };
+    expect(mortgageResult).toBeDefined();
+    expect(mortgageResult.monthlyPayment).toBe(1231123.01);
+  });
+});

--- a/libs/models/src/lib/mortgage-result.ts
+++ b/libs/models/src/lib/mortgage-result.ts
@@ -1,0 +1,5 @@
+export interface MortgageResult {
+    id: string;
+    monthlyPayment: number;
+    creationDate: Date;
+}

--- a/libs/shared-ui-services/src/lib/calculator-fixed-data.services.spec.ts
+++ b/libs/shared-ui-services/src/lib/calculator-fixed-data.services.spec.ts
@@ -1,6 +1,6 @@
 import mockAxios from 'jest-mock-axios';
 import { AxiosResponse } from 'axios';
-import { AmortizationPeriod, InterestRate, PaymentFrequency, RateType, Selectable, Term } from '@mortgage-calculator/models';
+import { AmortizationPeriod, InterestRate, PaymentFrequency, RateType,  Term } from '@mortgage-calculator/models';
 
 import { getTerms, getRateTypes, getInterestRate, getAmortizationPeriod, getPaymentFrequency } from './calculator-fixed-data.services';
 

--- a/libs/shared-ui-services/src/lib/calculator-mortgage.service.spec.ts
+++ b/libs/shared-ui-services/src/lib/calculator-mortgage.service.spec.ts
@@ -1,0 +1,39 @@
+import mockAxios from 'jest-mock-axios';
+import { AxiosResponse } from 'axios';
+
+import { generateMortgageGraphQL } from './calculator-mortgage.service';
+import { MortgageDetails, RateType, Term } from '@mortgage-calculator/models';
+import { getTerms } from './calculator-fixed-data.services';
+
+
+
+describe('getTerms', () => {
+
+  afterEach(() => {
+    // cleaning up the mess left behind the previous test
+    mockAxios.reset();
+  });
+  it('should be defined', () => {
+    expect( generateMortgageGraphQL ).toBeDefined();
+  });
+
+  it('should get a list of multiple terms', async () =>{
+
+    const mortgageInfo: MortgageDetails = {
+        mortgageAmount: 0,
+        prepaymentAmount: 0,
+        interestRate: 0,
+        amortizationYear: 0,
+        amortizationMonth: 0,
+        interestRateType: RateType.FIXED,
+        paymentFrequency: 0,
+        term: 0
+    }
+
+    const grqphQLQuery: string = generateMortgageGraphQL( mortgageInfo );
+
+    expect( grqphQLQuery ).toBeDefined();
+
+  });
+
+});

--- a/libs/shared-ui-services/src/lib/calculator-mortgage.service.spec.ts
+++ b/libs/shared-ui-services/src/lib/calculator-mortgage.service.spec.ts
@@ -1,11 +1,9 @@
 import mockAxios from 'jest-mock-axios';
-import { AxiosResponse } from 'axios';
 
-import { generateMortgageGraphQL } from './calculator-mortgage.service';
-import { MortgageDetails, RateType, Term } from '@mortgage-calculator/models';
-import { getTerms } from './calculator-fixed-data.services';
+import { calculateMortgage, generateMortgageGraphQL } from './calculator-mortgage.service';
+import { MortgageDetails, MortgageResult, RateType } from '@mortgage-calculator/models';
 
-
+jest.mock('axios');
 
 describe('getTerms', () => {
 
@@ -17,7 +15,7 @@ describe('getTerms', () => {
     expect( generateMortgageGraphQL ).toBeDefined();
   });
 
-  it('should get a list of multiple terms', async () =>{
+  it('should generate the grqphQL string', async () =>{
 
     const mortgageInfo: MortgageDetails = {
         mortgageAmount: 0,
@@ -30,10 +28,41 @@ describe('getTerms', () => {
         term: 0
     }
 
-    const grqphQLQuery: string = generateMortgageGraphQL( mortgageInfo );
-
-    expect( grqphQLQuery ).toBeDefined();
-
+    const graphQLQuery: string = generateMortgageGraphQL( mortgageInfo );
+    expect( graphQLQuery ).toBeDefined();
   });
+
+  it('should make api call to get graphql response', async () =>{
+
+    const mortgageInfo: MortgageDetails = {
+        mortgageAmount: 0,
+        prepaymentAmount: 0,
+        interestRate: 0,
+        amortizationYear: 0,
+        amortizationMonth: 0,
+        interestRateType: RateType.FIXED,
+        paymentFrequency: 0,
+        term: 0
+    }
+
+    const t =  {
+        "data": {
+            "getDefaultCalculation": {
+                "id":12319234243234234,
+                "monthlyPayment": 1212.31,
+                "creationDate": "2022-01-07T03:09:48.681Z"
+            }
+        }
+    };
+
+    mockAxios.post.mockResolvedValueOnce(t);
+
+    const morgageResult: MortgageResult = await calculateMortgage( 'http://localhost:8080', mortgageInfo );
+
+    expect( morgageResult ).toBeDefined();
+
+    expect( morgageResult.monthlyPayment ).toBe( 1212.31 );
+  });
+
 
 });

--- a/libs/shared-ui-services/src/lib/calculator-mortgage.service.ts
+++ b/libs/shared-ui-services/src/lib/calculator-mortgage.service.ts
@@ -4,9 +4,12 @@ import axios, {AxiosResponse} from "axios";
 // URL Definition
 const CALCULATE_MORTGAGE_URL = `/api/graphql`;
 
+interface GraphQResponse<T>  {
+    getDefaultCalculation:T
+}
 export const generateMortgageGraphQL = (mortgageInfo: MortgageDetails): string => {
     return `{
-        "query":"  mutation calculate{
+        "query":"mutation calculate{
             calculateMortgage( inputData: {
                 mortgageAmount: ${mortgageInfo.mortgageAmount},
                 prepaymentAmount: ${mortgageInfo.prepaymentAmount},
@@ -34,6 +37,7 @@ export const calculateMortgage = async ( baseUrl: string, mortgageInfo: Mortgage
 
     const graphQLMutationQuery:string =  generateMortgageGraphQL( mortgageInfo );
 
-    const mortgageResult : AxiosResponse<MortgageResult> = await axios.post( `${baseUrl}${CALCULATE_MORTGAGE_URL}`, graphQLMutationQuery );
-    return mortgageResult.data;
+
+    const mortgageResult : AxiosResponse<GraphQResponse<MortgageResult>> = await axios.post( `${baseUrl}${CALCULATE_MORTGAGE_URL}`, graphQLMutationQuery );
+    return mortgageResult.data.getDefaultCalculation;
 };

--- a/libs/shared-ui-services/src/lib/calculator-mortgage.service.ts
+++ b/libs/shared-ui-services/src/lib/calculator-mortgage.service.ts
@@ -1,0 +1,36 @@
+import { MortgageDetails, MortgageResult} from "@mortgage-calculator/models";
+import axios, {AxiosResponse} from "axios";
+
+// URL Definition
+const CALCULATE_MORTGAGE_URL = `/api/graphql`;
+
+const generateMortgageGraphQL = (mortgageInfo: MortgageDetails): string => {
+    return `{
+        "query":"  mutation calculate{
+            calculateMortgage( inputData: {
+                mortgageAmount: ${mortgageInfo.mortgageAmount},
+                prepaymentAmount: ${mortgageInfo.prepaymentAmount},
+                interestRate: ${mortgageInfo.interestRate},
+                amortizationYear: ${mortgageInfo.amortizationYear},
+                amortizationMonth: ${mortgageInfo.amortizationMonth},
+                interestRateType: '${mortgageInfo.interestRateType}',
+                paymentFrequency: ${mortgageInfo.paymentFrequency},
+                term: ${mortgageInfo.term}
+            }){
+                monthlyPayment
+                id
+                creationDate
+            }
+        }\n","variables":{}}`
+};
+
+/**
+ * The following function will make an API call to calculate the mortgage
+ * @param baseUrl
+ * @param mortgageInfo 
+ * @returns Promise<MortgageResult>
+ */
+export const calculateMortgage = async ( baseUrl: string, mortgageInfo: MortgageDetails ): Promise<MortgageResult> => {
+    const mortgageResult : AxiosResponse<MortgageResult> = await axios.post( `${baseUrl}${CALCULATE_MORTGAGE_URL}` );
+    return mortgageResult.data;
+};

--- a/libs/shared-ui-services/src/lib/calculator-mortgage.service.ts
+++ b/libs/shared-ui-services/src/lib/calculator-mortgage.service.ts
@@ -4,7 +4,7 @@ import axios, {AxiosResponse} from "axios";
 // URL Definition
 const CALCULATE_MORTGAGE_URL = `/api/graphql`;
 
-const generateMortgageGraphQL = (mortgageInfo: MortgageDetails): string => {
+export const generateMortgageGraphQL = (mortgageInfo: MortgageDetails): string => {
     return `{
         "query":"  mutation calculate{
             calculateMortgage( inputData: {
@@ -31,6 +31,9 @@ const generateMortgageGraphQL = (mortgageInfo: MortgageDetails): string => {
  * @returns Promise<MortgageResult>
  */
 export const calculateMortgage = async ( baseUrl: string, mortgageInfo: MortgageDetails ): Promise<MortgageResult> => {
-    const mortgageResult : AxiosResponse<MortgageResult> = await axios.post( `${baseUrl}${CALCULATE_MORTGAGE_URL}` );
+
+    const graphQLMutationQuery:string =  generateMortgageGraphQL( mortgageInfo );
+
+    const mortgageResult : AxiosResponse<MortgageResult> = await axios.post( `${baseUrl}${CALCULATE_MORTGAGE_URL}`, graphQLMutationQuery );
     return mortgageResult.data;
 };

--- a/libs/shared-ui-services/src/lib/calculator-mortgage.service.ts
+++ b/libs/shared-ui-services/src/lib/calculator-mortgage.service.ts
@@ -21,7 +21,7 @@ export const generateMortgageGraphQL = (mortgageInfo: MortgageDetails): string =
                 id
                 creationDate
             }
-        }\n","variables":{}}`
+        }","variables":{}}`
 };
 
 /**


### PR DESCRIPTION
The following is a partial PR that is in support of the bringing in the mortgage calclation API.  This PR includes creating the first service and test case to generate the data.  The next PR will focus on creating the actions and slice that integrates this into the UI